### PR TITLE
Fix issue with local stream.

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -42,14 +42,21 @@ hangupButton.onclick = hangup;
 
 function connect() {
   console.log("Requesting local stream");
-  navigator.getUserMedia({audio:true, video:true}, gotStream, error => {
+  navigator.getUserMedia({video:true}, gotStreamVideo, error => {
+          console.log("getUserMedia error: ", error);
+              });
+  navigator.getUserMedia({audio:true, video:true}, gotStreamAudioVideo, error => {
           console.log("getUserMedia error: ", error);
               });
 }
 
-function gotStream(stream) {
-  console.log("Received local stream");
+function gotStreamVideo(stream) {
+  console.log("Received local video stream");
   localVideo.src = URL.createObjectURL(stream);
+}
+
+function gotStreamAudioVideo(stream) {
+  console.log("Received local Audio/Video stream");
   localStream = stream;
   setupPeerConnection();
 }


### PR DESCRIPTION
Binding local stream video and audio to a video tag on the page causes the user to hear their own audio, which doesn't seem like the right approach.  This change makes it where the end-user will see their own video but hear and see the other person.
